### PR TITLE
feat(android): broadcast active track change events

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -40,6 +40,8 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val PLAYBACK_PLAY_WHEN_READY_CHANGED = "playback-play-when-ready-changed"
         const val PLAYBACK_STATE = "playback-state"
         const val PLAYBACK_ACTIVE_TRACK_CHANGED = "playback-active-track-changed"
+        const val PLAYBACK_ACTIVE_TRACK_CHANGED_INTENT =
+            "com.doublesymmetry.trackplayer.playback-active-track-changed"
         const val PLAYBACK_QUEUE_ENDED = "playback-queue-ended"
         const val PLAYBACK_METADATA = "playback-metadata-received"
         const val PLAYBACK_PROGRESS_UPDATED = "playback-progress-updated"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -515,6 +515,10 @@ class MusicService : HeadlessJsMediaService() {
             }
         }
         emit(MusicEvents.PLAYBACK_ACTIVE_TRACK_CHANGED, bundle)
+        // Broadcast active track changes for external listeners
+        val intent = Intent(MusicEvents.PLAYBACK_ACTIVE_TRACK_CHANGED_INTENT)
+        intent.putExtras(bundle)
+        sendBroadcast(intent)
     }
 
     private fun emitQueueEndedEvent() {

--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -23,6 +23,11 @@ Fired when the state of the player changes.
 
 The new event also includes the full track objects for the newly active and last tracks.
 
+On Android this event is also broadcast using an intent with the action
+`com.doublesymmetry.trackplayer.playback-active-track-changed`. A broadcast
+receiver can register for this action to be notified when the active track
+changes.
+
 | Param    | Type     | Description                               |
 | -------- | -------- | ----------------------------------------- |
 | lastIndex | `number`  \| `undefined` | The index of previously active track. |

--- a/docs/versioned_docs/version-5.0/api/events.md
+++ b/docs/versioned_docs/version-5.0/api/events.md
@@ -23,6 +23,11 @@ Fired when the state of the player changes.
 
 The new event also includes the full track objects for the newly active and last tracks.
 
+On Android this event is also broadcast using an intent with the action
+`com.doublesymmetry.trackplayer.playback-active-track-changed`. A broadcast
+receiver can register for this action to be notified when the active track
+changes.
+
 | Param    | Type     | Description                               |
 | -------- | -------- | ----------------------------------------- |
 | lastIndex | `number`  \| `undefined` | The index of previously active track. |


### PR DESCRIPTION
## Summary
- broadcast active track changes with a dedicated intent on Android
- document how to listen for active track change broadcasts

## Testing
- `yarn lint`
- `gradle -p android assemble` *(fails: Plugin with id 'com.facebook.react' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaa1bdc6883308802588c38299e42