### PR TITLE
feat(android): add native player setup helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * onStartCommandIntentValid ([26a5826](https://github.com/doublesymmetry/react-native-track-player/commit/26a5826c2214083b7106a44403e9fa29f9aed643))
 * **web:** add setQueue method ([#2394](https://github.com/doublesymmetry/react-native-track-player/issues/2394)) ([2765d09](https://github.com/doublesymmetry/react-native-track-player/commit/2765d09cb93541d89be94a4809320e4df33c0d47))
 * **web:** migrate web to turbomodule architecture ([f3fc4d5](https://github.com/doublesymmetry/react-native-track-player/commit/f3fc4d560154987dd7d341648b3ee6ac01972e15))
+* **android:** allow setting up the player from native Android code
 
 ### Bug Fixes
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayer.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayer.kt
@@ -1,0 +1,64 @@
+package com.doublesymmetry.trackplayer
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import androidx.media3.session.MediaBrowser
+import androidx.media3.session.SessionToken
+import com.doublesymmetry.trackplayer.service.MusicService
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+
+/**
+ * Utility object that allows controlling the player from native Android code
+ * such as widgets. It mirrors the behaviour of the React Native `setupPlayer`
+ * call so the player can be initialised without a React instance.
+ */
+object TrackPlayer : ServiceConnection {
+    private var isServiceBound = false
+    private var playerOptions: Bundle? = null
+    private val scope = MainScope()
+    private lateinit var musicService: MusicService
+    private var setupCallback: (() -> Unit)? = null
+
+    /**
+     * Bind to the [MusicService] and initialise the player.
+     * If the player has already been set up this call does nothing.
+     */
+    @JvmStatic
+    fun setupPlayer(context: Context, options: Bundle? = null, onSetupComplete: (() -> Unit)? = null) {
+        if (isServiceBound) {
+            onSetupComplete?.let { scope.launch { it() } }
+            return
+        }
+
+        playerOptions = options
+        setupCallback = onSetupComplete
+
+        Intent(context, MusicService::class.java).also { intent ->
+            context.bindService(intent, this, Context.BIND_AUTO_CREATE)
+            val sessionToken = SessionToken(context, ComponentName(context, MusicService::class.java))
+            MediaBrowser.Builder(context, sessionToken).buildAsync()
+        }
+    }
+
+    override fun onServiceConnected(name: ComponentName, service: IBinder) {
+        scope.launch {
+            val binder: MusicService.MusicBinder = service as MusicService.MusicBinder
+            musicService = binder.service
+            musicService.setupPlayer(playerOptions)
+            isServiceBound = true
+            setupCallback?.invoke()
+        }
+    }
+
+    override fun onServiceDisconnected(name: ComponentName) {
+        scope.launch {
+            isServiceBound = false
+        }
+    }
+}
+

--- a/docs/docs/api/functions/lifecycle.md
+++ b/docs/docs/api/functions/lifecycle.md
@@ -10,6 +10,10 @@ You should always call this function (even without any options set) before using
 
 Note that on Android this method must only be called while the app is in the foreground, otherwise it will throw an error with code `'android_cannot_setup_player_in_background'`. In this case you can wait for the app to be in the foreground and try again.
 
+If you need to initialise the player from native Android code (for example from an App Widget), the library exposes a Kotlin helper:
+`com.doublesymmetry.trackplayer.TrackPlayer.setupPlayer(context, bundle)`.
+Calling this mirrors the behaviour of the JavaScript `setupPlayer` call so the player can be prepared without a React instance.
+
 **Returns:** `Promise`
 
 | Param                | Type     | Description   | Default   | Android | iOS | Web |

--- a/docs/versioned_docs/version-5.0/api/functions/lifecycle.md
+++ b/docs/versioned_docs/version-5.0/api/functions/lifecycle.md
@@ -10,6 +10,10 @@ You should always call this function (even without any options set) before using
 
 Note that on Android this method must only be called while the app is in the foreground, otherwise it will throw an error with code `'android_cannot_setup_player_in_background'`. In this case you can wait for the app to be in the foreground and try again.
 
+If you need to initialise the player from native Android code (for example from an App Widget), the library exposes a Kotlin helper:
+`com.doublesymmetry.trackplayer.TrackPlayer.setupPlayer(context, bundle)`.
+Calling this mirrors the behaviour of the JavaScript `setupPlayer` call so the player can be prepared without a React instance.
+
 **Returns:** `Promise`
 
 | Param                | Type     | Description   | Default   | Android | iOS | Web |


### PR DESCRIPTION
## Summary
- expose `TrackPlayer.setupPlayer` to initialize the service from native Android code
- document native setup and update changelog

## Testing
- `npm test`
- `gradle compileDebugKotlin` *(fails: Plugin with id 'com.facebook.react' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeafed989483308680df3d643902ce